### PR TITLE
Update XRSimulator.gd To allow XRCamera3D to be renamed

### DIFF
--- a/addons/xr-simulator/XRSimulator.gd
+++ b/addons/xr-simulator/XRSimulator.gd
@@ -52,7 +52,10 @@ func _ready():
 	
 	origin = get_node(xr_origin)
 
-	camera = origin.get_node("XRCamera3D")
+	for i in origin.get_children():
+		if i is XRCamera3D:
+			camera = i
+			break
 	
 	var left_hand = XRServer.get_tracker("left_hand")
 	if left_hand == null:


### PR DESCRIPTION
Changes the ".get_node("XRCamera3D")" call to a for loop that searches for a node of type XRCamera3D. This allows for the node to be renamed and the program will still work